### PR TITLE
fix: update to scandi 5.2.x

### DIFF
--- a/packages/scandi-smpagebuilder/package.json
+++ b/packages/scandi-smpagebuilder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "scandi-smpagebuilder",
-    "version": "2.1.1",
+    "version": "3.0.0",
     "license": "OSL-3.0",
     "scandipwa": {
         "type": "extension",

--- a/packages/scandi-smpagebuilder/src/component/Pagebuilder/components/ProductCardWrapper/ProductCardWrapper.js
+++ b/packages/scandi-smpagebuilder/src/component/Pagebuilder/components/ProductCardWrapper/ProductCardWrapper.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const ProductCard = React.lazy(() => import('@scandipwa/scandipwa/src/component/ProductCard/ProductCard.container'));
+
+export const ProductCardWrapper = (props) => {
+  const {normalizedProduct} = props
+
+  return (
+      <ProductCard
+          product={normalizedProduct}
+          availableVisualOptions={['label']}
+          device={{}}
+          getAttribute={() => ''}
+          isBundleProductOutOfStock={() => false}
+          isConfigurableProductOutOfStock={() => false}
+          isPreview
+          inStock={normalizedProduct.stock_item.in_stock}
+          isWishlistEnabled={false}
+          productOrVariant={normalizedProduct}
+          thumbnail={normalizedProduct.image.url}
+          linkTo={normalizedProduct.url}
+          registerSharedElement={() => ''}
+          getActiveProduct={() => ({
+            ...normalizedProduct,
+            // type_id: normalizedProduct.baseType
+          })}
+          hideCompareButton={true}
+      />
+  );
+};
+

--- a/packages/scandi-smpagebuilder/src/component/Pagebuilder/components/ProductGrid/ProductGrid.js
+++ b/packages/scandi-smpagebuilder/src/component/Pagebuilder/components/ProductGrid/ProductGrid.js
@@ -4,6 +4,8 @@ import React from 'react';
 import { useProducts } from '../../hook/useProducts';
 
 import '../abe.scss';
+import { getIndexedProduct } from '@scandipwa/scandipwa/src/util/Product/Product';
+import {ProductCardWrapper} from "../ProductCardWrapper/ProductCardWrapper";
 
 export const ProductCard = React.lazy(() => import('@scandipwa/scandipwa/src/component/ProductCard/ProductCard.component'));
 
@@ -30,38 +32,18 @@ export const ProductGrid = (props) => {
     });
 
     const content = canRender ? data.products.items.map((productItem, indx) => {
-        const pOp = (productItem?.configurable_options || []).map((x) => ({
-            ...x,
-            attribute_code: x.attribute_code,
-            attribute_values: x.values
-        }));
+        const pOp = getIndexedProduct(productItem);
 
         return (
-            <ProductCard
-              key={ indx.toString() }
-              product={ {
-                  ...productItem,
-                  options: productItem?.options || [],
-                  configurable_options: pOp,
-                  variants: (productItem.variants || []).map((x) => x.product)
-              } }
-              availableVisualOptions={ ['label'] }
-              device={ {} }
-              getAttribute={ () => '' }
-              isBundleProductOutOfStock={ () => false }
-              isConfigurableProductOutOfStock={ () => false }
-              isPreview
-              isWishlistEnabled={ false }
-              productOrVariant={ productItem }
-              thumbnail={ productItem.image.url }
-              linkTo={ productItem.url }
-              registerSharedElement={ () => '' }
+            <ProductCardWrapper
+                key={indx}
+                normalizedProduct={pOp}
             />
         );
     }) : null;
 
     if (loading) {
-        return <Loader isLoading />;
+        return <Loader isLoading/>;
     }
 
     return (
@@ -71,9 +53,9 @@ export const ProductGrid = (props) => {
         //     </div>
         //     <div className="start-grid">
         <>
-                { content }
+            {content}
         </>
-    // </div>
+        // </div>
         // </div>
     );
 };

--- a/packages/scandi-smpagebuilder/src/component/Pagebuilder/components/ProductList/ProductList.js
+++ b/packages/scandi-smpagebuilder/src/component/Pagebuilder/components/ProductList/ProductList.js
@@ -1,10 +1,11 @@
 import Loader from '@scandipwa/scandipwa/src/component/Loader';
 
-const ProductCard = React.lazy(() => import('@scandipwa/scandipwa/src/component/ProductCard/ProductCard.component'));
 import React from 'react';
 import { useProducts } from '../../hook/useProducts';
 
 import '../abf.scss';
+import { getIndexedProduct } from '@scandipwa/scandipwa/src/util/Product/Product';
+import {ProductCardWrapper} from "../ProductCardWrapper/ProductCardWrapper";
 
 /** @namespace ScandiSmpagebuilder/Component/Pagebuilder/Components/ProductList/ProductList */
 export const ProductList = (props) => {
@@ -28,35 +29,12 @@ export const ProductList = (props) => {
 
                 <div className="overall-scroll">
                     {data.products.items.map((productItem, indx) => {
-                        const pOp = (productItem?.configurable_options || []).map((x) => ({
-                            ...x,
-                            attribute_code: x.attribute_code,
-                            attribute_values: x.values
-                        }));
+                        const pOp = getIndexedProduct(productItem);
 
                         return (
-                            <ProductCard
-                                key={indx.toString()}
-                                product={{
-                                    ...productItem,
-                                    options: productItem?.options || [],
-                                    configurable_options: pOp,
-                                    variants: (productItem.variants || []).map((x) => x.product)
-                                }}
-                                device={device || {}}
-                                getAttribute={() => null}
-                                isBundleProductOutOfStock={() => false}
-                                isConfigurableProductOutOfStock={() => false}
-                                isPreview
-                                isWishlistEnabled={false}
-                                productOrVariant={productItem}
-                                thumbnail={productItem.image.url}
-                                linkTo={productItem.url}
-                                registerSharedElement={() => ''}
-                                inStock
-                                parameters={{}}
-                                showSelectOptionsNotification={() => false}
-                                updateConfigurableVariant={() => null}
+                            <ProductCardWrapper
+                                key={indx}
+                                normalizedProduct={pOp}
                             />
                         );
                     })}

--- a/packages/scandi-smpagebuilder/src/component/Pagebuilder/components/ProductScroll/ProductScroll.js
+++ b/packages/scandi-smpagebuilder/src/component/Pagebuilder/components/ProductScroll/ProductScroll.js
@@ -1,11 +1,13 @@
 import Loader from '@scandipwa/scandipwa/src/component/Loader';
-const ProductCard = React.lazy(() => import('@scandipwa/scandipwa/src/component/ProductCard/ProductCard.component'));
+
 import React from 'react';
 
 import { useProducts } from '../../hook/useProducts';
 import { CarefreeHorizontalScroll } from '../CarefreeHorizontalScroll/CarefreeHorizontalScroll';
 
 import '../abg.scss';
+import { getIndexedProduct } from '@scandipwa/scandipwa/src/util/Product/Product';
+import {ProductCardWrapper} from "../ProductCardWrapper/ProductCardWrapper";
 
 /** @namespace ScandiSmpagebuilder/Component/Pagebuilder/Components/ProductScroll/ProductScroll */
 export const ProductScroll = (props) => {
@@ -22,47 +24,24 @@ export const ProductScroll = (props) => {
 
     if (canRender) {
         const products = data.products.items.map((productItem, indx) => {
-            const pOp = (productItem?.configurable_options || []).map((x) => ({
-                ...x,
-                attribute_code: x.attribute_code,
-                attribute_values: x.values
-            }));
+            const pOp = getIndexedProduct(productItem);
 
             return (
-                <ProductCard
-                  key={ indx.toString() }
-                  product={ {
-                      ...productItem,
-                      options: productItem?.options || [],
-                      configurable_options: pOp,
-                      variants: (productItem.variants || []).map((x) => x.product)
-                  } }
-                  availableVisualOptions={ ['label'] }
-                  device={ device || {} }
-                  getAttribute={ () => null }
-                  isBundleProductOutOfStock={ () => false }
-                  isConfigurableProductOutOfStock={ () => false }
-                  isPreview
-                  isWishlistEnabled={ false }
-                  productOrVariant={ productItem }
-                  thumbnail={ productItem.image.url }
-                  linkTo={ productItem.url }
-                  registerSharedElement={ () => '' }
-                  inStock
-                  parameters={ {} }
-                  showSelectOptionsNotification={ () => false }
-                  updateConfigurableVariant={ () => null }
+                <ProductCardWrapper
+                    key={indx}
+                    normalizedProduct={pOp}
                 />
             );
         });
 
         return (
-            <CarefreeHorizontalScroll item={ item } _class="product-scroll">
-                { products }
+            <CarefreeHorizontalScroll item={item} _class="product-scroll">
+                {products}
             </CarefreeHorizontalScroll>
         );
-    } if (loading) {
-        return <Loader isLoading />;
+    }
+    if (loading) {
+        return <Loader isLoading/>;
     }
 
     return '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12917,7 +12917,7 @@ saxes@^5.0.1:
     xmlchars "^2.2.0"
 
 "scandi-smpagebuilder@file:packages/scandi-smpagebuilder":
-  version "2.0.0"
+  version "2.2.1"
   dependencies:
     react-redux "^7.2.0"
     simi-pagebuilder-react "^1.3.0"


### PR DESCRIPTION
* Pass additional props `getActiveProduct` for __ProductCard__
* Use scandipwa lib's utility function to normalize product
* Hide compare product is tapita's dynamic product elements